### PR TITLE
Fix tvs pattern

### DIFF
--- a/ocaml-lsp-server/src/semantic_highlighting.ml
+++ b/ocaml-lsp-server/src/semantic_highlighting.ml
@@ -707,7 +707,7 @@ end = struct
       | Ppat_construct (c, args) ->
         let process_args () =
           Option.iter args ~f:(fun (tvs, pat) ->
-            List.iter tvs ~f:(fun (tv : _ Asttypes.loc) ->
+            List.iter tvs ~f:(fun ((tv : _ Asttypes.loc), _) ->
               add_token
                 tv.loc
                 (Token_type.of_builtin TypeParameter)


### PR DESCRIPTION
A quick fix to get ocaml-lsp building and useful with the current with-extensions upstream.